### PR TITLE
Changed straight path flags enum to a bitfield

### DIFF
--- a/Detour/Include/DetourNavMesh.h
+++ b/Detour/Include/DetourNavMesh.h
@@ -103,11 +103,16 @@ enum dtTileFlags
 };
 
 /// Vertex flags returned by dtNavMeshQuery::findStraightPath.
-enum dtStraightPathFlags
-{
-	DT_STRAIGHTPATH_START = 0x01,				///< The vertex is the start position in the path.
-	DT_STRAIGHTPATH_END = 0x02,					///< The vertex is the end position in the path.
-	DT_STRAIGHTPATH_OFFMESH_CONNECTION = 0x04,	///< The vertex is the start of an off-mesh connection.
+struct dtStraightPathFlags {
+	bool straightpathStart : 1;            ///< The vertex is the start position in the path.
+	bool straightpathEnd : 1;              ///< The vertex is the end position in the path.
+	bool straightpathOffmeshConection : 1; ///< The vertex is the start of an off-mesh connection.
+
+	dtStraightPathFlags()
+		: straightpathStart(false)
+		, straightpathEnd(false)
+		, straightpathOffmeshConection(false)
+	{}
 };
 
 /// Options for dtNavMeshQuery::findStraightPath.

--- a/Detour/Include/DetourNavMeshQuery.h
+++ b/Detour/Include/DetourNavMeshQuery.h
@@ -194,7 +194,7 @@ public:
 	/// @returns The status flags for the query.
 	dtStatus findStraightPath(const float* startPos, const float* endPos,
 							  const dtPolyRef* path, const int pathSize,
-							  float* straightPath, unsigned char* straightPathFlags, dtPolyRef* straightPathRefs,
+							  float* straightPath, dtStraightPathFlags* straightPathFlags, dtPolyRef* straightPathRefs,
 							  int* straightPathCount, const int maxStraightPath, const int options = 0) const;
 
 	///@}
@@ -494,13 +494,13 @@ private:
 							 float* mid) const;
 	
 	// Appends vertex to a straight path
-	dtStatus appendVertex(const float* pos, const unsigned char flags, const dtPolyRef ref,
-						  float* straightPath, unsigned char* straightPathFlags, dtPolyRef* straightPathRefs,
+	dtStatus appendVertex(const float* pos, dtStraightPathFlags flags, const dtPolyRef ref,
+						  float* straightPath, dtStraightPathFlags* straightPathFlags, dtPolyRef* straightPathRefs,
 						  int* straightPathCount, const int maxStraightPath) const;
 
 	// Appends intermediate portal points to a straight path.
 	dtStatus appendPortals(const int startIdx, const int endIdx, const float* endPos, const dtPolyRef* path,
-						   float* straightPath, unsigned char* straightPathFlags, dtPolyRef* straightPathRefs,
+						   float* straightPath, dtStraightPathFlags* straightPathFlags, dtPolyRef* straightPathRefs,
 						   int* straightPathCount, const int maxStraightPath, const int options) const;
 	
 	const dtNavMesh* m_nav;				///< Pointer to navmesh data.

--- a/DetourCrowd/Include/DetourCrowd.h
+++ b/DetourCrowd/Include/DetourCrowd.h
@@ -155,7 +155,7 @@ struct dtCrowdAgent
 	float cornerVerts[DT_CROWDAGENT_MAX_CORNERS*3];
 
 	/// The local path corridor corner flags. (See: #dtStraightPathFlags) [(flags) * #ncorners]
-	unsigned char cornerFlags[DT_CROWDAGENT_MAX_CORNERS];
+	dtStraightPathFlags cornerFlags[DT_CROWDAGENT_MAX_CORNERS];
 
 	/// The reference id of the polygon being entered at the corner. [(polyRef) * #ncorners]
 	dtPolyRef cornerPolys[DT_CROWDAGENT_MAX_CORNERS];

--- a/DetourCrowd/Include/DetourPathCorridor.h
+++ b/DetourCrowd/Include/DetourPathCorridor.h
@@ -55,7 +55,7 @@ public:
 	///  @param[in]		navquery		The query object used to build the corridor.
 	///  @param[in]		filter			The filter to apply to the operation.
 	/// @return The number of corners returned in the corner buffers. [0 <= value <= @p maxCorners]
-	int findCorners(float* cornerVerts, unsigned char* cornerFlags,
+	int findCorners(float* cornerVerts, dtStraightPathFlags* cornerFlags,
 					dtPolyRef* cornerPolys, const int maxCorners,
 					dtNavMeshQuery* navquery, const dtQueryFilter* filter);
 	

--- a/DetourCrowd/Source/DetourCrowd.cpp
+++ b/DetourCrowd/Source/DetourCrowd.cpp
@@ -79,7 +79,7 @@ static bool overOffmeshConnection(const dtCrowdAgent* ag, const float radius)
 	if (!ag->ncorners)
 		return false;
 	
-	const bool offMeshConnection = (ag->cornerFlags[ag->ncorners-1] & DT_STRAIGHTPATH_OFFMESH_CONNECTION) ? true : false;
+	const bool offMeshConnection = ag->cornerFlags[ag->ncorners-1].straightpathOffmeshConection;
 	if (offMeshConnection)
 	{
 		const float distSq = dtVdist2DSqr(ag->npos, &ag->cornerVerts[(ag->ncorners-1)*3]);
@@ -95,7 +95,7 @@ static float getDistanceToGoal(const dtCrowdAgent* ag, const float range)
 	if (!ag->ncorners)
 		return range;
 	
-	const bool endOfPath = (ag->cornerFlags[ag->ncorners-1] & DT_STRAIGHTPATH_END) ? true : false;
+	const bool endOfPath = ag->cornerFlags[ag->ncorners-1].straightpathEnd;
 	if (endOfPath)
 		return dtMin(dtVdist2D(ag->npos, &ag->cornerVerts[(ag->ncorners-1)*3]), range);
 	

--- a/DetourCrowd/Source/DetourPathCorridor.cpp
+++ b/DetourCrowd/Source/DetourPathCorridor.cpp
@@ -248,7 +248,7 @@ So if 10 corners are needed, the buffers should be sized for 11 corners.
 
 If the target is within range, it will be the last corner and have a polygon reference id of zero.
 */
-int dtPathCorridor::findCorners(float* cornerVerts, unsigned char* cornerFlags,
+int dtPathCorridor::findCorners(float* cornerVerts, dtStraightPathFlags* cornerFlags,
 							  dtPolyRef* cornerPolys, const int maxCorners,
 							  dtNavMeshQuery* navquery, const dtQueryFilter* /*filter*/)
 {
@@ -264,7 +264,7 @@ int dtPathCorridor::findCorners(float* cornerVerts, unsigned char* cornerFlags,
 	// Prune points in the beginning of the path which are too close.
 	while (ncorners)
 	{
-		if ((cornerFlags[0] & DT_STRAIGHTPATH_OFFMESH_CONNECTION) ||
+		if (cornerFlags[0].straightpathOffmeshConection ||
 			dtVdist2DSqr(&cornerVerts[0], m_pos) > dtSqr(MIN_TARGET_DIST))
 			break;
 		ncorners--;
@@ -279,7 +279,7 @@ int dtPathCorridor::findCorners(float* cornerVerts, unsigned char* cornerFlags,
 	// Prune points after an off-mesh connection.
 	for (int i = 0; i < ncorners; ++i)
 	{
-		if (cornerFlags[i] & DT_STRAIGHTPATH_OFFMESH_CONNECTION)
+		if (cornerFlags[i].straightpathOffmeshConection)
 		{
 			ncorners = i+1;
 			break;

--- a/DetourCrowd/Source/DetourPathCorridor.cpp
+++ b/DetourCrowd/Source/DetourPathCorridor.cpp
@@ -270,7 +270,7 @@ int dtPathCorridor::findCorners(float* cornerVerts, dtStraightPathFlags* cornerF
 		ncorners--;
 		if (ncorners)
 		{
-			memmove(cornerFlags, cornerFlags+1, sizeof(unsigned char)*ncorners);
+			memmove(cornerFlags, cornerFlags+1, sizeof(dtStraightPathFlags)*ncorners);
 			memmove(cornerPolys, cornerPolys+1, sizeof(dtPolyRef)*ncorners);
 			memmove(cornerVerts, cornerVerts+3, sizeof(float)*3*ncorners);
 		}

--- a/RecastDemo/Include/NavMeshTesterTool.h
+++ b/RecastDemo/Include/NavMeshTesterTool.h
@@ -59,7 +59,7 @@ class NavMeshTesterTool : public SampleTool
 	dtPolyRef m_parent[MAX_POLYS];
 	int m_npolys;
 	float m_straightPath[MAX_POLYS*3];
-	unsigned char m_straightPathFlags[MAX_POLYS];
+	dtStraightPathFlags m_straightPathFlags[MAX_POLYS];
 	dtPolyRef m_straightPathPolys[MAX_POLYS];
 	int m_nstraightPath;
 	float m_polyPickExt[3];

--- a/RecastDemo/Source/CrowdTool.cpp
+++ b/RecastDemo/Source/CrowdTool.cpp
@@ -319,7 +319,7 @@ void CrowdToolState::handleRender()
 					dd.vertex(va[0],va[1]+radius,va[2], duRGBA(128,0,0,192));
 					dd.vertex(vb[0],vb[1]+radius,vb[2], duRGBA(128,0,0,192));
 				}
-				if (ag->ncorners && ag->cornerFlags[ag->ncorners-1] & DT_STRAIGHTPATH_OFFMESH_CONNECTION)
+				if (ag->ncorners && ag->cornerFlags[ag->ncorners-1].straightpathOffmeshConection)
 				{
 					const float* v = &ag->cornerVerts[(ag->ncorners-1)*3];
 					dd.vertex(v[0],v[1],v[2], duRGBA(192,0,0,192));


### PR DESCRIPTION
This shouldn't have any effect at all on the execution of the code, but it makes it a lot easier to read.  

Is the conversion at Detour/Source/DetourNavMeshQuery.cpp:1630 correct or should the original code have been `flags & DT_STRAIGHTPATH_END`?