### PR TITLE
Add support to use GLFW (linux only for now);

### DIFF
--- a/RecastDemo/Include/wnd.h
+++ b/RecastDemo/Include/wnd.h
@@ -1,0 +1,108 @@
+#ifndef WND_H
+#define WND_H
+
+#if !defined(USE_GLFW)
+
+#include "SDL.h"
+#include "SDL_opengl.h"
+
+#define WND_QUIT                    SDL_QUIT
+
+#define WND_KEY_1                   SDLK_1
+#define WND_KEY_9                   SDLK_9
+#define WND_KEY_0                   SDLK_0
+#define WND_KEY_W                   SDLK_w
+#define WND_KEY_S                   SDLK_s
+#define WND_KEY_A                   SDLK_a
+#define WND_KEY_D                   SDLK_d
+#define WND_KEY_T                   SDLK_t
+#define WND_KEY_TAB                 SDLK_TAB
+#define WND_KEY_RIGHT               SDLK_RIGHT
+#define WND_KEY_LEFT                SDLK_LEFT
+#define WND_KEY_SPACE               SDLK_SPACE
+#define WND_KEY_ESCAPE              SDLK_ESCAPE
+
+#define WND_KMOD_SHIFT              KMOD_SHIFT
+#define WND_KMOD_CTRL               KMOD_CTRL
+
+#define WND_MOUSE_BUTTON_LEFT       SDL_BUTTON_LEFT
+#define WND_MOUSE_BUTTON_RIGHT      SDL_BUTTON_RIGHT
+#define WND_MOUSE_WHEEL_UP          SDL_BUTTON_WHEELUP
+#define WND_MOUSE_WHEEL_DOWN        SDL_BUTTON_WHEELDOWN
+
+#define WND_KEY_PRESSED             SDL_KEYDOWN
+#define WND_KEY_RELEASED            SDL_KEYUP
+#define WND_MOUSE_BUTTON_PRESSED    SDL_MOUSEBUTTONDOWN
+#define WND_MOUSE_BUTTON_RELEASED   SDL_MOUSEBUTTONUP
+#define WND_MOUSE_MOVED             SDL_MOUSEMOTION
+
+#else // USE_GLFW
+
+#include <GL/gl.h>
+#include <GL/glu.h>
+#include <GLFW/glfw3.h>
+
+#define WND_KEY_1                   GLFW_KEY_1
+#define WND_KEY_9                   GLFW_KEY_9
+#define WND_KEY_0                   GLFW_KEY_0
+#define WND_KEY_W                   GLFW_KEY_W
+#define WND_KEY_S                   GLFW_KEY_S
+#define WND_KEY_A                   GLFW_KEY_A
+#define WND_KEY_D                   GLFW_KEY_D
+#define WND_KEY_T                   GLFW_KEY_T
+#define WND_KEY_TAB                 GLFW_KEY_TAB
+#define WND_KEY_RIGHT               GLFW_KEY_RIGHT
+#define WND_KEY_LEFT                GLFW_KEY_LEFT
+#define WND_KEY_SPACE               GLFW_KEY_SPACE
+#define WND_KEY_ESCAPE              GLFW_KEY_ESCAPE
+
+#define WND_KMOD_SHIFT              GLFW_MOD_SHIFT
+#define WND_KMOD_CTRL               GLFW_MOD_CONTROL
+
+#define WND_MOUSE_BUTTON_LEFT       GLFW_MOUSE_BUTTON_LEFT
+#define WND_MOUSE_BUTTON_RIGHT      GLFW_MOUSE_BUTTON_RIGHT
+#define WND_MOUSE_WHEEL_UP          (GLFW_MOUSE_BUTTON_LAST + 1)
+#define WND_MOUSE_WHEEL_DOWN        (GLFW_MOUSE_BUTTON_LAST + 2)
+
+#define WND_KEY_PRESSED             1
+#define WND_KEY_RELEASED            2
+#define WND_MOUSE_BUTTON_PRESSED    3
+#define WND_MOUSE_BUTTON_RELEASED   4
+#define WND_MOUSE_MOVED             5
+#define WND_QUIT                    6
+
+#endif
+
+struct wnd_event_key
+{
+    int type;
+    int code;
+};
+
+struct wnd_event_mouse
+{
+    int type;
+    int button;
+    int x;
+    int y;
+};
+
+typedef union wnd_event
+{
+    int type;
+    wnd_event_key   key;
+    wnd_event_mouse mouse;
+} wnd_event;
+
+bool wnd_init(int* width, int* height, bool presentationMode);
+void wnd_quit();
+double wnd_ticks();
+bool wnd_poll_event(wnd_event& event);
+void wnd_sleep(int ms);
+void wnd_swap();
+bool wnd_mod_state(int kmod);
+bool wnd_get_key(int key);
+bool wnd_get_mouse(int button);
+
+#endif // WND_H
+

--- a/RecastDemo/Source/ConvexVolumeTool.cpp
+++ b/RecastDemo/Source/ConvexVolumeTool.cpp
@@ -21,8 +21,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <float.h>
-#include "SDL.h"
-#include "SDL_opengl.h"
+#include "wnd.h"
 #include "imgui.h"
 #include "ConvexVolumeTool.h"
 #include "InputGeom.h"

--- a/RecastDemo/Source/CrowdTool.cpp
+++ b/RecastDemo/Source/CrowdTool.cpp
@@ -21,8 +21,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <float.h>
-#include "SDL.h"
-#include "SDL_opengl.h"
+#include "wnd.h"
 #include "imgui.h"
 #include "CrowdTool.h"
 #include "InputGeom.h"

--- a/RecastDemo/Source/NavMeshPruneTool.cpp
+++ b/RecastDemo/Source/NavMeshPruneTool.cpp
@@ -21,8 +21,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <float.h>
-#include "SDL.h"
-#include "SDL_opengl.h"
+#include "wnd.h"
 #include "imgui.h"
 #include "NavMeshPruneTool.h"
 #include "InputGeom.h"

--- a/RecastDemo/Source/NavMeshTesterTool.cpp
+++ b/RecastDemo/Source/NavMeshTesterTool.cpp
@@ -21,8 +21,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "SDL.h"
-#include "SDL_opengl.h"
+#include "wnd.h"
 #include "imgui.h"
 #include "NavMeshTesterTool.h"
 #include "Sample.h"

--- a/RecastDemo/Source/OffMeshConnectionTool.cpp
+++ b/RecastDemo/Source/OffMeshConnectionTool.cpp
@@ -21,8 +21,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <float.h>
-#include "SDL.h"
-#include "SDL_opengl.h"
+#include "wnd.h"
 #include "imgui.h"
 #include "OffMeshConnectionTool.h"
 #include "InputGeom.h"

--- a/RecastDemo/Source/Sample.cpp
+++ b/RecastDemo/Source/Sample.cpp
@@ -28,8 +28,7 @@
 #include "DetourNavMeshQuery.h"
 #include "DetourCrowd.h"
 #include "imgui.h"
-#include "SDL.h"
-#include "SDL_opengl.h"
+#include "wnd.h"
 
 #ifdef WIN32
 #	define snprintf _snprintf

--- a/RecastDemo/Source/SampleInterfaces.cpp
+++ b/RecastDemo/Source/SampleInterfaces.cpp
@@ -2,13 +2,13 @@
 #include <math.h>
 #include <stdio.h>
 #include <stdarg.h>
+#include <string.h>
 #include "SampleInterfaces.h"
 #include "Recast.h"
 #include "RecastDebugDraw.h"
 #include "DetourDebugDraw.h"
 #include "PerfTimer.h"
-#include "SDL.h"
-#include "SDL_opengl.h"
+#include "wnd.h"
 
 #ifdef WIN32
 #	define snprintf _snprintf

--- a/RecastDemo/Source/Sample_Debug.cpp
+++ b/RecastDemo/Source/Sample_Debug.cpp
@@ -27,8 +27,7 @@
 #include "DetourDebugDraw.h"
 #include "RecastDump.h"
 #include "imgui.h"
-#include "SDL.h"
-#include "SDL_opengl.h"
+#include "wnd.h"
 
 #ifdef WIN32
 #	define snprintf _snprintf

--- a/RecastDemo/Source/Sample_SoloMesh.cpp
+++ b/RecastDemo/Source/Sample_SoloMesh.cpp
@@ -20,8 +20,7 @@
 #include <math.h>
 #include <stdio.h>
 #include <string.h>
-#include "SDL.h"
-#include "SDL_opengl.h"
+#include "wnd.h"
 #include "imgui.h"
 #include "InputGeom.h"
 #include "Sample.h"

--- a/RecastDemo/Source/Sample_TempObstacles.cpp
+++ b/RecastDemo/Source/Sample_TempObstacles.cpp
@@ -22,8 +22,7 @@
 #include <string.h>
 #include <float.h>
 #include <new>
-#include "SDL.h"
-#include "SDL_opengl.h"
+#include "wnd.h"
 #include "imgui.h"
 #include "InputGeom.h"
 #include "Sample.h"

--- a/RecastDemo/Source/Sample_TileMesh.cpp
+++ b/RecastDemo/Source/Sample_TileMesh.cpp
@@ -20,8 +20,7 @@
 #include <math.h>
 #include <stdio.h>
 #include <string.h>
-#include "SDL.h"
-#include "SDL_opengl.h"
+#include "wnd.h"
 #include "imgui.h"
 #include "InputGeom.h"
 #include "Sample.h"
@@ -1100,14 +1099,14 @@ unsigned char* Sample_TileMesh::buildTileMesh(const int tx, const int ty, const 
 		if (!rcBuildDistanceField(m_ctx, *m_chf))
 		{
 			m_ctx->log(RC_LOG_ERROR, "buildNavigation: Could not build distance field.");
-			return false;
+			return 0;
 		}
 		
 		// Partition the walkable surface into simple regions without holes.
 		if (!rcBuildRegions(m_ctx, *m_chf, m_cfg.borderSize, m_cfg.minRegionArea, m_cfg.mergeRegionArea))
 		{
 			m_ctx->log(RC_LOG_ERROR, "buildNavigation: Could not build watershed regions.");
-			return false;
+			return 0;
 		}
 	}
 	else if (m_partitionType == SAMPLE_PARTITION_MONOTONE)
@@ -1117,7 +1116,7 @@ unsigned char* Sample_TileMesh::buildTileMesh(const int tx, const int ty, const 
 		if (!rcBuildRegionsMonotone(m_ctx, *m_chf, m_cfg.borderSize, m_cfg.minRegionArea, m_cfg.mergeRegionArea))
 		{
 			m_ctx->log(RC_LOG_ERROR, "buildNavigation: Could not build monotone regions.");
-			return false;
+			return 0;
 		}
 	}
 	else // SAMPLE_PARTITION_LAYERS
@@ -1126,7 +1125,7 @@ unsigned char* Sample_TileMesh::buildTileMesh(const int tx, const int ty, const 
 		if (!rcBuildLayerRegions(m_ctx, *m_chf, m_cfg.borderSize, m_cfg.minRegionArea))
 		{
 			m_ctx->log(RC_LOG_ERROR, "buildNavigation: Could not build layer regions.");
-			return false;
+			return 0;
 		}
 	}
 	 	

--- a/RecastDemo/Source/SlideShow.cpp
+++ b/RecastDemo/Source/SlideShow.cpp
@@ -16,10 +16,10 @@
 // 3. This notice may not be removed or altered from any source distribution.
 //
 
+#include "wnd.h"
 #include "SlideShow.h"
 #include <string.h>
 #include <stdio.h>
-#include <SDL_opengl.h>
 //#define STBI_HEADER_FILE_ONLY
 #include "stb_image.h"
 

--- a/RecastDemo/Source/TestCase.cpp
+++ b/RecastDemo/Source/TestCase.cpp
@@ -24,8 +24,7 @@
 #include "DetourNavMesh.h"
 #include "DetourNavMeshQuery.h"
 #include "DetourCommon.h"
-#include "SDL.h"
-#include "SDL_opengl.h"
+#include "wnd.h"
 #include "imgui.h"
 #include "PerfTimer.h"
 

--- a/RecastDemo/Source/imguiRenderGL.cpp
+++ b/RecastDemo/Source/imguiRenderGL.cpp
@@ -18,9 +18,9 @@
 
 #define _USE_MATH_DEFINES
 #include <math.h>
+#include <stdio.h>
 #include "imgui.h"
-#include "SDL.h"
-#include "SDL_opengl.h"
+#include "wnd.h"
 
 // Some math headers don't have PI defined.
 static const float PI = 3.14159265f;

--- a/RecastDemo/Source/main.cpp
+++ b/RecastDemo/Source/main.cpp
@@ -19,8 +19,8 @@
 #include <stdio.h>
 #define _USE_MATH_DEFINES
 #include <math.h>
-#include "SDL.h"
-#include "SDL_opengl.h"
+#include <string.h>
+#include "wnd.h"
 #include "imgui.h"
 #include "imguiRenderGL.h"
 #include "Recast.h"
@@ -58,75 +58,28 @@ static SampleItem g_samples[] =
 	{ createTempObstacle, "Temp Obstacles" },
 //	{ createDebug, "Debug" },
 };
-static const int g_nsamples = sizeof(g_samples)/sizeof(SampleItem); 
+static const int g_nsamples = sizeof(g_samples)/sizeof(SampleItem);
 
 
 int main(int /*argc*/, char** /*argv*/)
 {
-	// Init SDL
-	if (SDL_Init(SDL_INIT_EVERYTHING) != 0)
-	{
-		printf("Could not initialise SDL\n");
-		return -1;
-	}
-	
-	// Center window
-	char env[] = "SDL_VIDEO_CENTERED=1";
-	putenv(env);
-
-	// Init OpenGL
-	SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
-	SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
-	SDL_GL_SetAttribute(SDL_GL_RED_SIZE, 8);
-	SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, 8);
-	SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE, 8);
-	SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, 8);
-//#ifndef WIN32
-	SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 1);
-	SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, 4);
-//#endif
-
-	const SDL_VideoInfo* vi = SDL_GetVideoInfo();
-
+    int width, height;
 	bool presentationMode = false;
-
-	int width, height;
-	SDL_Surface* screen = 0;
-	
-	if (presentationMode)
-	{
-		width = vi->current_w;
-		height = vi->current_h;
-		screen = SDL_SetVideoMode(width, height, 0, SDL_OPENGL|SDL_FULLSCREEN);
-	}
-	else
-	{	
-		width = rcMin(vi->current_w, (int)(vi->current_h * 16.0 / 9.0));
-		width = width - 80;
-		height = vi->current_h - 80;
-		screen = SDL_SetVideoMode(width, height, 0, SDL_OPENGL);
-	}
-	
-	if (!screen)
-	{
-		printf("Could not initialise SDL opengl\n");
+	if (!wnd_init(&width, &height, presentationMode))
 		return -1;
-	}
 
 	glEnable(GL_MULTISAMPLE);
 
-	SDL_WM_SetCaption("Recast Demo", 0);
-	
 	if (!imguiRenderGLInit("DroidSans.ttf"))
 	{
 		printf("Could not init GUI renderer.\n");
-		SDL_Quit();
+		wnd_quit();
 		return -1;
 	}
-	
+
 	float t = 0.0f;
 	float timeAcc = 0.0f;
-	Uint32 lastTime = SDL_GetTicks();
+	double lastTime = wnd_ticks();
 	int mx = 0, my = 0;
 	float rx = 45;
 	float ry = -45;
@@ -137,7 +90,7 @@ int main(int /*argc*/, char** /*argv*/)
 	float scrollZoom = 0;
 	bool rotate = false;
 	bool movedDuringRotate = false;
-	float rays[3], raye[3]; 
+	float rays[3], raye[3];
 	bool mouseOverMenu = false;
 	bool showMenu = !presentationMode;
 	bool showLog = false;
@@ -149,35 +102,35 @@ int main(int /*argc*/, char** /*argv*/)
 	int propScroll = 0;
 	int logScroll = 0;
 	int toolsScroll = 0;
-	
-	char sampleName[64] = "Choose Sample..."; 
-	
+
+	char sampleName[64] = "Choose Sample...";
+
 	FileList files;
 	char meshName[128] = "Choose Mesh...";
-	
+
 	float mpos[3] = {0,0,0};
 	bool mposSet = false;
-	
+
 	SlideShow slideShow;
 	slideShow.init("slides/");
-	
+
 	InputGeom* geom = 0;
 	Sample* sample = 0;
 	TestCase* test = 0;
 
 	BuildContext ctx;
-	
+
 	glEnable(GL_CULL_FACE);
-	
+
 	float fogCol[4] = { 0.32f, 0.31f, 0.30f, 1.0f };
 	glEnable(GL_FOG);
 	glFogi(GL_FOG_MODE, GL_LINEAR);
 	glFogf(GL_FOG_START, camr*0.1f);
 	glFogf(GL_FOG_END, camr*1.25f);
 	glFogfv(GL_FOG_COLOR, fogCol);
-	
+
 	glDepthFunc(GL_LEQUAL);
-	
+
 	bool done = false;
 	while(!done)
 	{
@@ -185,45 +138,45 @@ int main(int /*argc*/, char** /*argv*/)
 		int mscroll = 0;
 		bool processHitTest = false;
 		bool processHitTestShift = false;
-		SDL_Event event;
-		
-		while (SDL_PollEvent(&event))
+		wnd_event event;
+
+		while (wnd_poll_event(event))
 		{
 			switch (event.type)
 			{
-				case SDL_KEYDOWN:
+				case WND_KEY_PRESSED:
 					// Handle any key presses here.
-					if (event.key.keysym.sym == SDLK_ESCAPE)
+					if (event.key.code == WND_KEY_ESCAPE)
 					{
 						done = true;
 					}
-					else if (event.key.keysym.sym == SDLK_t)
+					else if (event.key.code == WND_KEY_T)
 					{
 						showLevels = false;
 						showSample = false;
 						showTestCases = true;
 						scanDirectory("Tests", ".txt", files);
 					}
-					else if (event.key.keysym.sym == SDLK_TAB)
+					else if (event.key.code == WND_KEY_TAB)
 					{
 						showMenu = !showMenu;
 					}
-					else if (event.key.keysym.sym == SDLK_SPACE)
+					else if (event.key.code == WND_KEY_SPACE)
 					{
 						if (sample)
 							sample->handleToggle();
 					}
-					else if (event.key.keysym.sym == SDLK_1)
+					else if (event.key.code == WND_KEY_1)
 					{
 						if (sample)
 							sample->handleStep();
 					}
-					else if (event.key.keysym.sym == SDLK_9)
+					else if (event.key.code == WND_KEY_9)
 					{
 						if (geom)
 							geom->save("geomset.txt");
 					}
-					else if (event.key.keysym.sym == SDLK_0)
+					else if (event.key.code == WND_KEY_0)
 					{
 						delete geom;
 						geom = new InputGeom;
@@ -231,7 +184,7 @@ int main(int /*argc*/, char** /*argv*/)
 						{
 							delete geom;
 							geom = 0;
-							
+
 							showLog = true;
 							logScroll = 0;
 							ctx.dumpLog("Geom load log %s:", meshName);
@@ -240,7 +193,7 @@ int main(int /*argc*/, char** /*argv*/)
 						{
 							sample->handleMeshChanged(geom);
 						}
-							
+
 						if (geom || sample)
 						{
 							const float* bmin = 0;
@@ -272,18 +225,18 @@ int main(int /*argc*/, char** /*argv*/)
 							glFogf(GL_FOG_END, camr*1.25f);
 						}
 					}
-					else if (event.key.keysym.sym == SDLK_RIGHT)
+					else if (event.key.code == WND_KEY_RIGHT)
 					{
 						slideShow.nextSlide();
 					}
-					else if (event.key.keysym.sym == SDLK_LEFT)
+					else if (event.key.code == WND_KEY_LEFT)
 					{
 						slideShow.prevSlide();
 					}
 					break;
-					
-				case SDL_MOUSEBUTTONDOWN:
-					if (event.button.button == SDL_BUTTON_RIGHT)
+
+				case WND_MOUSE_BUTTON_PRESSED:
+					if (event.mouse.button == WND_MOUSE_BUTTON_RIGHT)
 					{
 						if (!mouseOverMenu)
 						{
@@ -295,15 +248,15 @@ int main(int /*argc*/, char** /*argv*/)
 							origrx = rx;
 							origry = ry;
 						}
-					}	
-					else if (event.button.button == SDL_BUTTON_WHEELUP)
+					}
+					else if (event.mouse.button == WND_MOUSE_WHEEL_UP)
 					{
 						if (mouseOverMenu)
 							mscroll--;
 						else
 							scrollZoom -= 1.0f;
 					}
-					else if (event.button.button == SDL_BUTTON_WHEELDOWN)
+					else if (event.mouse.button == WND_MOUSE_WHEEL_DOWN)
 					{
 						if (mouseOverMenu)
 							mscroll++;
@@ -311,10 +264,10 @@ int main(int /*argc*/, char** /*argv*/)
 							scrollZoom += 1.0f;
 					}
 					break;
-					
-				case SDL_MOUSEBUTTONUP:
+
+				case WND_MOUSE_BUTTON_RELEASED:
 					// Handle mouse clicks here.
-					if (event.button.button == SDL_BUTTON_RIGHT)
+					if (event.mouse.button == WND_MOUSE_BUTTON_RIGHT)
 					{
 						rotate = false;
 						if (!mouseOverMenu)
@@ -326,20 +279,20 @@ int main(int /*argc*/, char** /*argv*/)
 							}
 						}
 					}
-					else if (event.button.button == SDL_BUTTON_LEFT)
+					else if (event.mouse.button == WND_MOUSE_BUTTON_LEFT)
 					{
 						if (!mouseOverMenu)
 						{
 							processHitTest = true;
-							processHitTestShift = (SDL_GetModState() & KMOD_SHIFT) ? true : false;
+							processHitTestShift = wnd_mod_state(WND_KMOD_SHIFT) ? true : false;
 						}
 					}
-					
+
 					break;
-					
-				case SDL_MOUSEMOTION:
-					mx = event.motion.x;
-					my = height-1 - event.motion.y;
+
+				case WND_MOUSE_MOVED:
+					mx = event.mouse.x;
+					my = height-1 - event.mouse.y;
 					if (rotate)
 					{
 						int dx = mx - origx;
@@ -350,26 +303,26 @@ int main(int /*argc*/, char** /*argv*/)
 							movedDuringRotate = true;
 					}
 					break;
-					
-				case SDL_QUIT:
+
+				case WND_QUIT:
 					done = true;
 					break;
-					
+
 				default:
 					break;
 			}
 		}
 
 		unsigned char mbut = 0;
-		if (SDL_GetMouseState(0,0) & SDL_BUTTON_LMASK)
+		if (wnd_get_mouse(WND_MOUSE_BUTTON_LEFT))
 			mbut |= IMGUI_MBUT_LEFT;
-		if (SDL_GetMouseState(0,0) & SDL_BUTTON_RMASK)
+		if (wnd_get_mouse(WND_MOUSE_BUTTON_RIGHT))
 			mbut |= IMGUI_MBUT_RIGHT;
-		
-		Uint32	time = SDL_GetTicks();
+
+		double	time = wnd_ticks();
 		float	dt = (time - lastTime) / 1000.0f;
 		lastTime = time;
-		
+
 		t += dt;
 
 
@@ -378,10 +331,10 @@ int main(int /*argc*/, char** /*argv*/)
 		{
 			float hitt;
 			bool hit = geom->raycastMesh(rays, raye, hitt);
-			
+
 			if (hit)
 			{
-				if (SDL_GetModState() & KMOD_CTRL)
+				if (wnd_mod_state(WND_KMOD_CTRL))
 				{
 					// Marker
 					mposSet = true;
@@ -400,14 +353,14 @@ int main(int /*argc*/, char** /*argv*/)
 			}
 			else
 			{
-				if (SDL_GetModState() & KMOD_CTRL)
+				if (wnd_mod_state(WND_KMOD_CTRL))
 				{
 					// Marker
 					mposSet = false;
 				}
 			}
 		}
-		
+
 		// Update sample simulation.
 		const float SIM_RATE = 20;
 		const float DELTA_TIME = 1.0f/SIM_RATE;
@@ -431,10 +384,10 @@ int main(int /*argc*/, char** /*argv*/)
 			int ms = (int)((MIN_FRAME_TIME - dt)*1000.0f);
 			if (ms > 10) ms = 10;
 			if (ms >= 0)
-				SDL_Delay(ms);
+				wnd_sleep(ms);
 		}
-		
-		
+
+
 		// Update and render
 		glViewport(0, 0, width, height);
 		glClearColor(0.3f, 0.3f, 0.32f, 1.0f);
@@ -442,7 +395,7 @@ int main(int /*argc*/, char** /*argv*/)
 		glEnable(GL_BLEND);
 		glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 		glDisable(GL_TEXTURE_2D);
-		
+
 		// Render 3d
 		glEnable(GL_DEPTH_TEST);
 		glMatrixMode(GL_PROJECTION);
@@ -453,7 +406,7 @@ int main(int /*argc*/, char** /*argv*/)
 		glRotatef(rx,1,0,0);
 		glRotatef(ry,0,1,0);
 		glTranslatef(-camx, -camy, -camz);
-		
+
 		// Get hit ray position and direction.
 		GLdouble proj[16];
 		GLdouble model[16];
@@ -466,28 +419,27 @@ int main(int /*argc*/, char** /*argv*/)
 		rays[0] = (float)x; rays[1] = (float)y; rays[2] = (float)z;
 		gluUnProject(mx, my, 1.0f, model, proj, view, &x, &y, &z);
 		raye[0] = (float)x; raye[1] = (float)y; raye[2] = (float)z;
-		
+
 		// Handle keyboard movement.
-		Uint8* keystate = SDL_GetKeyState(NULL);
-		moveW = rcClamp(moveW + dt * 4 * (keystate[SDLK_w] ? 1 : -1), 0.0f, 1.0f);
-		moveS = rcClamp(moveS + dt * 4 * (keystate[SDLK_s] ? 1 : -1), 0.0f, 1.0f);
-		moveA = rcClamp(moveA + dt * 4 * (keystate[SDLK_a] ? 1 : -1), 0.0f, 1.0f);
-		moveD = rcClamp(moveD + dt * 4 * (keystate[SDLK_d] ? 1 : -1), 0.0f, 1.0f);
-		
+		moveW = rcClamp(moveW + dt * 4 * (wnd_get_key(WND_KEY_W) ? 1 : -1), 0.0f, 1.0f);
+		moveS = rcClamp(moveS + dt * 4 * (wnd_get_key(WND_KEY_S) ? 1 : -1), 0.0f, 1.0f);
+		moveA = rcClamp(moveA + dt * 4 * (wnd_get_key(WND_KEY_A) ? 1 : -1), 0.0f, 1.0f);
+		moveD = rcClamp(moveD + dt * 4 * (wnd_get_key(WND_KEY_D) ? 1 : -1), 0.0f, 1.0f);
+
 		float keybSpeed = 22.0f;
-		if (SDL_GetModState() & KMOD_SHIFT)
+		if (wnd_mod_state(WND_KMOD_SHIFT))
 			keybSpeed *= 4.0f;
-		
+
 		float movex = (moveD - moveA) * keybSpeed * dt;
 		float movey = (moveS - moveW) * keybSpeed * dt;
-		
+
 		movey += scrollZoom * 2.0f;
 		scrollZoom = 0;
-		
+
 		camx += movex * (float)model[0];
 		camy += movex * (float)model[4];
 		camz += movex * (float)model[8];
-		
+
 		camx += movey * (float)model[2];
 		camy += movey * (float)model[6];
 		camz += movey * (float)model[10];
@@ -498,9 +450,9 @@ int main(int /*argc*/, char** /*argv*/)
 			sample->handleRender();
 		if (test)
 			test->handleRender();
-		
+
 		glDisable(GL_FOG);
-		
+
 		// Render GUI
 		glDisable(GL_DEPTH_TEST);
 		glMatrixMode(GL_PROJECTION);
@@ -508,11 +460,11 @@ int main(int /*argc*/, char** /*argv*/)
 		gluOrtho2D(0, width, 0, height);
 		glMatrixMode(GL_MODELVIEW);
 		glLoadIdentity();
-		
+
 		mouseOverMenu = false;
-		
+
 		imguiBeginFrame(mx,my,mbut,mscroll);
-		
+
 		if (sample)
 		{
 			sample->handleRenderOverlay((double*)proj, (double*)model, (int*)view);
@@ -529,7 +481,7 @@ int main(int /*argc*/, char** /*argv*/)
 			const char msg[] = "W/S/A/D: Move  RMB: Rotate";
 			imguiDrawText(280, height-20, IMGUI_ALIGN_LEFT, msg, imguiRGBA(255,255,255,128));
 		}
-		
+
 		if (showMenu)
 		{
 			if (imguiBeginScrollArea("Properties", width-250-10, 10, 250, height-20, &propScroll))
@@ -555,7 +507,7 @@ int main(int /*argc*/, char** /*argv*/)
 					showTestCases = false;
 				}
 			}
-			
+
 			imguiSeparator();
 			imguiLabel("Input Mesh");
 			if (imguiButton(meshName))
@@ -585,7 +537,7 @@ int main(int /*argc*/, char** /*argv*/)
 			if (geom && sample)
 			{
 				imguiSeparatorLine();
-				
+
 				sample->handleSettings();
 
 				if (imguiButton("Build"))
@@ -597,7 +549,7 @@ int main(int /*argc*/, char** /*argv*/)
 						logScroll = 0;
 					}
 					ctx.dumpLog("Build log %s:", meshName);
-					
+
 					// Clear test.
 					delete test;
 					test = 0;
@@ -605,7 +557,7 @@ int main(int /*argc*/, char** /*argv*/)
 
 				imguiSeparator();
 			}
-			
+
 			if (sample)
 			{
 				imguiSeparatorLine();
@@ -614,7 +566,7 @@ int main(int /*argc*/, char** /*argv*/)
 
 			imguiEndScrollArea();
 		}
-		
+
 		// Sample selection dialog.
 		if (showSample)
 		{
@@ -674,43 +626,43 @@ int main(int /*argc*/, char** /*argv*/)
 				glFogf(GL_FOG_START, camr*0.1f);
 				glFogf(GL_FOG_END, camr*1.25f);
 			}
-			
+
 			imguiEndScrollArea();
 		}
-		
+
 		// Level selection dialog.
 		if (showLevels)
 		{
 			static int levelScroll = 0;
 			if (imguiBeginScrollArea("Choose Level", width-10-250-10-200, height-10-450, 200, 450, &levelScroll))
 				mouseOverMenu = true;
-			
+
 			int levelToLoad = -1;
 			for (int i = 0; i < files.size; ++i)
 			{
 				if (imguiItem(files.files[i]))
 					levelToLoad = i;
 			}
-			
+
 			if (levelToLoad != -1)
 			{
 				strncpy(meshName, files.files[levelToLoad], sizeof(meshName));
 				meshName[sizeof(meshName)-1] = '\0';
 				showLevels = false;
-				
+
 				delete geom;
 				geom = 0;
-				
+
 				char path[256];
 				strcpy(path, "Meshes/");
 				strcat(path, meshName);
-				
+
 				geom = new InputGeom;
 				if (!geom || !geom->loadMesh(&ctx, path))
 				{
 					delete geom;
 					geom = 0;
-					
+
 					showLog = true;
 					logScroll = 0;
 					ctx.dumpLog("Geom load log %s:", meshName);
@@ -751,11 +703,11 @@ int main(int /*argc*/, char** /*argv*/)
 					glFogf(GL_FOG_END, camr*1.25f);
 				}
 			}
-			
+
 			imguiEndScrollArea();
-			
+
 		}
-		
+
 		// Test cases
 		if (showTestCases)
 		{
@@ -769,7 +721,7 @@ int main(int /*argc*/, char** /*argv*/)
 				if (imguiItem(files.files[i]))
 					testToLoad = i;
 			}
-			
+
 			if (testToLoad != -1)
 			{
 				char path[256];
@@ -806,13 +758,13 @@ int main(int /*argc*/, char** /*argv*/)
 					// Load geom.
 					strcpy(meshName, test->getGeomFileName());
 					meshName[sizeof(meshName)-1] = '\0';
-					
+
 					delete geom;
 					geom = 0;
-					
+
 					strcpy(path, "Meshes/");
 					strcat(path, meshName);
-					
+
 					geom = new InputGeom;
 					if (!geom || !geom->loadMesh(&ctx, path))
 					{
@@ -836,7 +788,7 @@ int main(int /*argc*/, char** /*argv*/)
 					{
 						ctx.dumpLog("Build log %s:", meshName);
 					}
-					
+
 					if (geom || sample)
 					{
 						const float* bmin = 0;
@@ -867,17 +819,17 @@ int main(int /*argc*/, char** /*argv*/)
 						glFogf(GL_FOG_START, camr*0.2f);
 						glFogf(GL_FOG_END, camr*1.25f);
 					}
-					
+
 					// Do the tests.
 					if (sample)
 						test->doTests(sample->getNavMesh(), sample->getNavMeshQuery());
 				}
-			}				
-				
+			}
+
 			imguiEndScrollArea();
 		}
 
-		
+
 		// Log
 		if (showLog && showMenu)
 		{
@@ -887,7 +839,7 @@ int main(int /*argc*/, char** /*argv*/)
 				imguiLabel(ctx.getLogText(i));
 			imguiEndScrollArea();
 		}
-		
+
 		// Tools
 		if (!showTestCases && showTools && showMenu) // && geom && sample)
 		{
@@ -896,12 +848,12 @@ int main(int /*argc*/, char** /*argv*/)
 
 			if (sample)
 				sample->handleTools();
-			
+
 			imguiEndScrollArea();
 		}
-		
+
 		slideShow.updateAndDraw(dt, (float)width, (float)height);
-		
+
 		// Marker
 		if (mposSet && gluProject((GLdouble)mpos[0], (GLdouble)mpos[1], (GLdouble)mpos[2],
 								  model, proj, view, &x, &y, &z))
@@ -921,20 +873,20 @@ int main(int /*argc*/, char** /*argv*/)
 			glEnd();
 			glLineWidth(1.0f);
 		}
-		
+
 		imguiEndFrame();
-		imguiRenderGLDraw();		
-		
+		imguiRenderGLDraw();
+
 		glEnable(GL_DEPTH_TEST);
-		SDL_GL_SwapBuffers();
+		wnd_swap();
 	}
-	
+
 	imguiRenderGLDestroy();
-	
-	SDL_Quit();
-	
+
+	wnd_quit();
+
 	delete sample;
 	delete geom;
-	
+
 	return 0;
 }

--- a/RecastDemo/Source/wnd_glfw.cpp
+++ b/RecastDemo/Source/wnd_glfw.cpp
@@ -1,0 +1,146 @@
+#include "wnd.h"
+
+#if defined(USE_GLFW)
+
+#include <queue>
+#include <algorithm>
+#include <stdio.h>
+
+static bool _should_quit = false;
+static GLFWwindow* _window = 0;
+static int _current_mods = 0;
+static std::queue<wnd_event> _events;
+
+void key_cb(GLFWwindow* window, int key, int scancode, int action, int mods)
+{
+    _current_mods = mods;
+
+    wnd_event evt;
+    evt.type = action == GLFW_PRESS ? WND_KEY_PRESSED : WND_KEY_RELEASED;
+    evt.key.code = key;
+    _events.push(evt);
+}
+
+void mouse_move_cb(GLFWwindow* window, double x, double y)
+{
+    wnd_event evt;
+    evt.type = WND_MOUSE_MOVED;
+    evt.mouse.x = int(x);
+    evt.mouse.y = int(y);
+    _events.push(evt);
+}
+
+void mouse_button_cb(GLFWwindow* window, int button, int action, int mods)
+{
+    wnd_event evt;
+    evt.type = action == GLFW_PRESS ? WND_MOUSE_BUTTON_PRESSED : WND_MOUSE_BUTTON_RELEASED;
+    evt.mouse.button = button;
+    _events.push(evt);
+}
+
+void mouse_scroll_cb(GLFWwindow* window, double x, double y)
+{
+    wnd_event evt;
+    evt.type = WND_MOUSE_BUTTON_PRESSED;
+    evt.mouse.button = y > 0 ? WND_MOUSE_WHEEL_UP : WND_MOUSE_WHEEL_DOWN;
+    _events.push(evt);
+}
+
+bool wnd_init(int* width, int* height, bool presentationMode)
+{
+    if (!glfwInit())
+    {
+		printf("Could not initialise GLFW\n");
+        return false;
+    }
+
+    GLFWmonitor* fullscreen = 0;
+    const GLFWvidmode* mode = glfwGetVideoMode(glfwGetPrimaryMonitor());
+    if (presentationMode)
+    {
+        *width = mode->width;
+        *height = mode->height;
+        fullscreen = glfwGetPrimaryMonitor();
+    }
+    else
+    {
+        *width = std::min(mode->width, (int)(mode->height * 16.0 / 9.0));
+        *width = *width - 80;
+        *height = mode->height - 80;
+    }
+
+    _window = glfwCreateWindow(*width, *height, "Recast Demo", fullscreen, NULL);
+    if (!_window)
+    {
+		printf("Could not initialise GLFW window\n");
+		return false;
+    }
+
+    glfwSetKeyCallback(_window, key_cb);
+    glfwSetCursorPosCallback(_window, mouse_move_cb);
+    glfwSetScrollCallback(_window, mouse_scroll_cb);
+    glfwSetMouseButtonCallback(_window, mouse_button_cb);
+
+    glfwMakeContextCurrent(_window);
+    glfwSwapInterval(1);
+
+    return true;
+}
+
+void wnd_quit()
+{
+    glfwTerminate();
+}
+
+double wnd_ticks()
+{
+    return glfwGetTime();
+}
+
+bool wnd_poll_event(wnd_event& event)
+{
+    if (_events.empty())
+        return false;
+
+    event = _events.front();
+    _events.pop();
+
+    return true;
+}
+
+void wnd_sleep(int ms)
+{
+    // sleep
+}
+
+void wnd_swap()
+{
+    glfwSwapBuffers(_window);
+    glfwPollEvents();
+
+    if (glfwWindowShouldClose(_window) && !_should_quit)
+    {
+        _should_quit = true;
+        wnd_event evt;
+        evt.type = WND_QUIT;
+        _events.push(evt);
+    }
+}
+
+bool wnd_mod_state(int kmod)
+{
+    return _current_mods & kmod;
+}
+
+bool wnd_get_key(int key)
+{
+    return glfwGetKey(_window, key) == GLFW_PRESS;
+}
+
+bool wnd_get_mouse(int button)
+{
+    return glfwGetMouseButton(_window, button) == GLFW_PRESS;
+}
+
+#endif // USE_GLFW
+

--- a/RecastDemo/Source/wnd_sdl.cpp
+++ b/RecastDemo/Source/wnd_sdl.cpp
@@ -1,0 +1,124 @@
+#include "wnd.h"
+
+#if !defined(USE_GLFW)
+
+#include <algorithm>
+
+bool wnd_init(int* width, int* height, bool presentationMode)
+{
+    if (SDL_Init(SDL_INIT_EVERYTHING) != 0)
+    {
+		printf("Could not initialise SDL\n");
+        return false;
+    }
+
+	// Center window
+	char env[] = "SDL_VIDEO_CENTERED=1";
+	putenv(env);
+
+	// Init OpenGL
+	SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
+	SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
+	SDL_GL_SetAttribute(SDL_GL_RED_SIZE, 8);
+	SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, 8);
+	SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE, 8);
+	SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, 8);
+//#ifndef WIN32
+	SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 1);
+	SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, 4);
+//#endif
+
+	const SDL_VideoInfo* vi = SDL_GetVideoInfo();
+
+	SDL_Surface* screen = 0;
+	if (presentationMode)
+	{
+		*width = vi->current_w;
+		*height = vi->current_h;
+		screen = SDL_SetVideoMode(*width, *height, 0, SDL_OPENGL|SDL_FULLSCREEN);
+	}
+	else
+	{
+		*width = std::min(vi->current_w, (int)(vi->current_h * 16.0 / 9.0));
+		*width = *width - 80;
+		*height = vi->current_h - 80;
+		screen = SDL_SetVideoMode(*width, *height, 0, SDL_OPENGL);
+	}
+
+	if (!screen)
+	{
+		printf("Could not initialise SDL opengl\n");
+		return false;
+	}
+
+	SDL_WM_SetCaption("Recast Demo", 0);
+
+    return true;
+}
+
+void wnd_quit()
+{
+    SDL_Quit();
+}
+
+double wnd_ticks()
+{
+    return (double)SDL_GetTicks();
+}
+
+bool wnd_poll_event(wnd_event& event)
+{
+    SDL_Event e;
+    if (SDL_PollEvent(&e))
+    {
+        event.type = e.type;
+        switch (e.type)
+        {
+            case SDL_KEYDOWN:
+            case SDL_KEYUP:
+                event.key.code = e.key.keysym.sym;
+                break;
+            case SDL_MOUSEBUTTONDOWN:
+            case SDL_MOUSEBUTTONUP:
+                event.mouse.button = e.button.button;
+                break;
+            case SDL_MOUSEMOTION:
+                event.mouse.x = e.motion.x;
+                event.mouse.y = e.motion.y;
+                break;
+        }
+
+        return true;
+    }
+
+    return false;
+}
+
+void wnd_sleep(int ms)
+{
+    SDL_Delay(ms);
+}
+
+void wnd_swap()
+{
+    SDL_GL_SwapBuffers();
+}
+
+bool wnd_mod_state(int kmod)
+{
+    return SDL_GetModState() & kmod;
+}
+
+bool wnd_get_key(int key)
+{
+    return SDL_GetKeyState(NULL)[key] == 1;
+}
+
+bool wnd_get_mouse(int button)
+{
+    int mask = (button == WND_MOUSE_BUTTON_LEFT) ? SDL_BUTTON_LMASK : SDL_BUTTON_RMASK;
+    return (SDL_GetMouseState(0, 0) & mask);
+}
+
+#endif // !USE_GLFW
+

--- a/RecastDemo/premake4.lua
+++ b/RecastDemo/premake4.lua
@@ -132,8 +132,13 @@ project "RecastDemo"
 	-- distribute executable in RecastDemo/Bin directory
 	targetdir "Bin"
 
+	newoption {
+		trigger 	= "use-glfw",
+		description = "Force use GLFW3 instead of SDL"
+	}
+
 	-- linux library cflags and libs
-	configuration { "linux", "gmake" }
+	configuration { "linux", "gmake", "not use-glfw" }
 		buildoptions { 
 			"`pkg-config --cflags sdl`",
 			"`pkg-config --cflags gl`",
@@ -145,6 +150,28 @@ project "RecastDemo"
 			"`pkg-config --libs glu`" 
 		}
 
+	configuration { "linux", "gmake", "use-glfw" }
+		defines { "USE_GLFW" }
+		buildoptions { 
+			"`pkg-config --cflags glfw3`",
+			"`pkg-config --cflags gl`",
+			"`pkg-config --cflags glu`" 
+		}
+		linkoptions { 
+			"`pkg-config --libs glfw3`",
+			"`pkg-config --libs gl`",
+			"`pkg-config --libs glu`" 
+		}
+        links {
+            "pthread",
+            "X11",
+            "Xrandr",
+            "Xinerama",
+            "Xi",
+            "Xxf86vm",
+            "Xcursor"
+        }
+		
 	-- windows library cflags and libs
 	configuration { "windows" }
 		includedirs { "../RecastDemo/Contrib/SDL/include" }


### PR DESCRIPTION
This implements a very thin and (ugly?)hacky layer that makes glfw behave as SDL, so to avoid a major rewrite of RecastDemo main.

I've added a premake option "--use-glfw" with a configuration for linux only (for now), adding support to windows and macosx should be trivial and need only changes to the premake file. I'm not doing this right now due to not being able to test it on these platforms.

Also note that the premake file changes may not be optimal, I still do not have a good premake knowledge.

Why GLFW?

Firstly because I've [implemented](https://github.com/fungos/fips-recast) support to [fips build system](https://github.com/floooh/fips) and at this moment we haven't a fipsified SDL build, only GLFW. 
But also, GLFW is an easier, good and lightweight alternative to SDL.

Why FIPS?

Fips is an amazing build system based on CMake where it manage all your (fips) dependencies automaticaly, having more and more fipsified projects means lower friction to programmers when adding and maintaining thirdparty dependencies. For example, commonly used "contrib" directories with instructions, git submodules, or just duplicated dependencies aren't needed anymore. Also, users using projects with this kind of dependencies will have not to worry anymore about Doing The Right Thing(tm).