### PR TITLE
reset agent desired velocity in resetMoveTarget

### DIFF
--- a/DetourCrowd/Source/DetourCrowd.cpp
+++ b/DetourCrowd/Source/DetourCrowd.cpp
@@ -653,6 +653,7 @@ bool dtCrowd::resetMoveTarget(const int idx)
 	// Initialize request.
 	ag->targetRef = 0;
 	dtVset(ag->targetPos, 0,0,0);
+	dtVset(ag->dvel, 0,0,0);
 	ag->targetPathqRef = DT_PATHQ_INVALID;
 	ag->targetReplan = false;
 	ag->targetState = DT_CROWDAGENT_TARGET_NONE;


### PR DESCRIPTION
Otherwise, if velocity was non zero at time resetMoveTarget is called the agent would continue to move indefinitely at that velocity (a straight line) which was not the intended behaviour.

As discussed in https://groups.google.com/forum/#!topic/recastnavigation/QoLNGz5o6e8