### PR TITLE
Include hit edge index in dtRaycastHit.

### DIFF
--- a/Detour/Include/DetourNavMeshQuery.h
+++ b/Detour/Include/DetourNavMeshQuery.h
@@ -131,6 +131,9 @@ struct dtRaycastHit
 	
 	/// hitNormal	The normal of the nearest wall hit. [(x, y, z)]
 	float hitNormal[3];
+
+	/// The index of the edge on the final polygon where the wall was hit.
+	int hitEdgeIndex;
 	
 	/// Pointer to an array of reference ids of the visited polygons. [opt]
 	dtPolyRef* path;

--- a/Detour/Source/DetourNavMeshQuery.cpp
+++ b/Detour/Source/DetourNavMeshQuery.cpp
@@ -2420,6 +2420,9 @@ dtStatus dtNavMeshQuery::raycast(dtPolyRef startRef, const float* startPos, cons
 			hit->pathCount = n;
 			return status;
 		}
+
+		hit->hitEdgeIndex = segMax;
+
 		// Keep track of furthest t so far.
 		if (tmax > hit->t)
 			hit->t = tmax;


### PR DESCRIPTION
This makes it simpler to investigate exactly what is blocking a ray - for example, if an agent cannot move onto a polygon due to QueryFilter flags, then this provides a way for the agent to find out which flags it needs to have and to perform a state change which alters its movement flags.