### PR TITLE
Add support for rasterizing filled convex volumes and filled OBBs

### DIFF
--- a/Recast/Include/Recast.h
+++ b/Recast/Include/Recast.h
@@ -850,6 +850,32 @@ void rcRasterizeTriangles(rcContext* ctx, const float* verts, const int nv,
 void rcRasterizeTriangles(rcContext* ctx, const float* verts, const unsigned char* areas, const int nt,
 						  rcHeightfield& solid, const int flagMergeThr = 1);
 
+/// Rasterizes a solid (i.e. filled) convex volume defined by a set of points into the specified heightfield.
+///  @ingroup recast
+///  @param[in,out]	ctx				The build context to use during the operation.
+///  @param[in]		vertices		The vertices of the volume. [(x, y, z) * @p numVertices]
+///  @param[in]		numVertices		The number of vertices in the volume.
+///  @param[in]		area			The area id of the volume. [Limit: <= #RC_WALKABLE_AREA]
+///  @param[in,out]	solid			An initialized heightfield.
+///  @param[in]		flagMergeThr	The distance where the walkable flag is favored over the non-walkable flag.
+///  								[Limit: >= 0] [Units: vx]
+void rcRasterizeFilledConvexVolume(rcContext* ctx, const float* vertices, const int numVertices, const unsigned char area,
+								   rcHeightfield& solid, int flagMergeThr = 1);
+
+/// Rasterizes a solid (i.e. filled) OBB into the specified heightfield.
+///  @ingroup recast
+///  @param[in,out]	ctx				The build context to use during the operation.
+///  @param[in]		center			The center position of the OBB.
+///  @param[in]		extent			The extents of the OBB (half the size)
+///  @param[in]		forward			The forward-vector of the OBB's orientation
+///  @param[in]		up				The up-vector of the OBB's orientation
+///  @param[in]		area			The area id of the OBB. [Limit: <= #RC_WALKABLE_AREA]
+///  @param[in,out]	solid			An initialized heightfield.
+///  @param[in]		flagMergeThr	The distance where the walkable flag is favored over the non-walkable flag.
+///  								[Limit: >= 0] [Units: vx]
+void rcRasterizeFilledOBB(rcContext* ctx, const float* center, const float* extent, const float* forward, const float* up,
+						  const unsigned char area, rcHeightfield& solid, int flagMergeThr = 1);
+
 /// Marks non-walkable spans as walkable if their maximum is within @p walkableClimp of a walkable neihbor. 
 ///  @ingroup recast
 ///  @param[in,out]	ctx				The build context to use during the operation.


### PR DESCRIPTION
Add methods for rasterising filled volumes: arbitrary convex volumes (defined by a set of points), and OBBs (defined by center/extent and forward/up vectors).

This should make it a bit easier to feed Recast with 'solid' data and stop it generating navmesh inside objects, etc.

Arbitrary convex volumes are handled by rasterising all the triangles that compose the volume into a temporary second highfield, and then coalescing all the spans in each cell of that heightfield and merging it back into the main one. OBBs just calculate the vertices and then hand off to the convex volume code.